### PR TITLE
Some improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 20 03:25:34 EST 2018
+#Sun May 13 14:36:53 KRAT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
@@ -579,6 +579,10 @@ public class ChipsInputLayout extends MaxHeightScrollView
         }
     }
 
+    public ChipsEditText getChipsInputEditText() {
+        return mChipsInput;
+    }
+
     /**
      * Sets the image renderer used to load chip avatars.
      * @param renderer {@link ChipImageRenderer}


### PR DESCRIPTION
Release notes: 

- updated gradle to 3.1.0
- added getter to ChipsInput EditText

Note: ChipsInput EditText have getter or have to be protected, because then we cannot clean text in the field or add custom textwatcher. 