### PR TITLE
Upkeep & add custom delimiter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Attribute | Type | Summary
 `app:allowCustomChips` | `boolean` | True if user is allowed to enter custom chips.
 `app:hideKeyboardOnChipClick` | `boolean` | True if the keyboard should hide when a filterable chip is clicked.
 `app:maxRows` | `int` | Maximum number of rows used to display chips.
+`app:delimiter` | `string` | A custom delimiter used to submit new chips.
+`app:delimiterRegex` | `boolean` | True if `app:delimiter` is a regular expression.
 `app:chip_showDetails` | `boolean` | True if clicking a chip should show its details.
 `app:chip_showAvatar` | `boolean` | True if each chip should show an avatar icon.
 `app:chip_showDelete` | `boolean` | True if each chip should be deletable by the user.
@@ -101,6 +103,8 @@ Method | Summary
 `setHideKeyboardOnChipClick(boolean)` | True if the keyboard should hide when filterable chip is clicked.
 `setMaxRows(int)` | Changes maximum number of rows used to display chips.
 `setTypeface(Typeface)` | Changes the typeface of the ChipsInputLayout and all associated textual-based components.
+`setDelimiter(String)` | Sets the customer delimiter to be used to separate new chips.
+`setDelimiter(String, boolean)` | Sets the customer delimiter to be used to separate new chips. Boolean is whether string is a regular expression or not.
 `setChipTitleTextColor(ColorStateList)` | Changes text color of each chips' title and subtitle.
 `setShowChipAvatarEnabled(boolean)` | True if each chip should show an avatar icon.
 `setChipsDeletable(boolean)` | True if each chip should be deletable by the user.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,15 +20,15 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:28.0.0-rc01'
-    compile 'com.android.support:design:28.0.0-rc01'
-    compile 'com.android.support.constraint:constraint-layout:1.1.2'
-    testCompile 'junit:junit:4.12'
-    compile project(':library')
+    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
+    implementation 'com.android.support:design:28.0.0-rc01'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    testImplementation 'junit:junit:4.12'
+    implementation project(':library')
 
-    compile 'com.github.bumptech.glide:glide:4.0.0'
+    implementation 'com.github.bumptech.glide:glide:4.0.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.2"
     defaultConfig {
         applicationId "com.tylersuehr.chips"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -24,9 +24,9 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support:appcompat-v7:28.0.0-rc01'
+    compile 'com.android.support:design:28.0.0-rc01'
+    compile 'com.android.support.constraint:constraint-layout:1.1.2'
     testCompile 'junit:junit:4.12'
     compile project(':library')
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,15 +22,15 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:28.0.0-rc01'
-    compile 'com.android.support:recyclerview-v7:28.0.0-rc01'
-    compile 'com.android.support.constraint:constraint-layout:1.1.2'
-    compile 'com.beloo.widget:ChipsLayoutManager:0.3.7@aar'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
+    implementation 'com.android.support:recyclerview-v7:28.0.0-rc01'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.beloo.widget:ChipsLayoutManager:0.3.7@aar'
+    testImplementation 'junit:junit:4.12'
 }
 
 apply plugin: 'com.github.dcendents.android-maven'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -26,9 +26,9 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:recyclerview-v7:26.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support:appcompat-v7:28.0.0-rc01'
+    compile 'com.android.support:recyclerview-v7:28.0.0-rc01'
+    compile 'com.android.support.constraint:constraint-layout:1.1.2'
     compile 'com.beloo.widget:ChipsLayoutManager:0.3.7@aar'
     testCompile 'junit:junit:4.12'
 }

--- a/library/src/main/java/com/tylersuehr/chips/ChipOptions.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipOptions.java
@@ -47,6 +47,8 @@ final class ChipOptions {
     boolean mAllowCustomChips;
     boolean mHideKeyboardOnChipClick;
     int mMaxRows;
+    String mDelimiter;
+    boolean mDelimiterRegex;
 
     @NonNull
     ChipImageRenderer mImageRenderer;
@@ -87,6 +89,8 @@ final class ChipOptions {
         mAllowCustomChips = a.getBoolean(R.styleable.ChipsInputLayout_allowCustomChips, true);
         mHideKeyboardOnChipClick = a.getBoolean(R.styleable.ChipsInputLayout_hideKeyboardOnChipClick, true);
         mMaxRows = a.getInt(R.styleable.ChipsInputLayout_maxRows, 3);
+        mDelimiter = a.getString(R.styleable.ChipsInputLayout_delimiter);
+        mDelimiterRegex = a.getBoolean(R.styleable.ChipsInputLayout_delimiterRegex, false);
 
         a.recycle();
 

--- a/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
+++ b/library/src/main/java/com/tylersuehr/chips/ChipsInputLayout.java
@@ -19,6 +19,7 @@ import android.widget.RelativeLayout;
 import com.beloo.widget.chipslayoutmanager.ChipsLayoutManager;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Copyright © 2017 Tyler Suehr
@@ -579,6 +580,15 @@ public class ChipsInputLayout extends MaxHeightScrollView
         }
     }
 
+    public void setDelimiter(String delimiter, boolean regex){
+        mOptions.mDelimiter = delimiter;
+        mOptions.mDelimiterRegex = regex;
+    }
+
+    public void setDelimiter(String delimiter){
+        setDelimiter(delimiter, false);
+    }
+
     public ChipsEditText getChipsInputEditText() {
         return mChipsInput;
     }
@@ -683,6 +693,18 @@ public class ChipsInputLayout extends MaxHeightScrollView
                         onTextChanged(s, 0, 0, 0);
                     }
                 }, 1500);
+            }
+
+            String delimiter = mOptions.mDelimiter;
+            if(delimiter != null && delimiter.length() > 0 && mChipsInput.getKeyboardListener() != null){
+                String delimiterRegex = mOptions.mDelimiterRegex ? delimiter : Pattern.quote(delimiter);
+                final String text = s.toString();
+                if(Pattern.compile(delimiterRegex).matcher(text).find()){
+                    final String[] pieces = text.split(delimiterRegex);
+                    for(String piece : pieces) {
+                        mChipsInput.getKeyboardListener().onKeyboardActionDone(piece);
+                    }
+                }
             }
         }
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -18,6 +18,8 @@
         <attr name="allowCustomChips" format="boolean"/>
         <attr name="hideKeyboardOnChipClick" format="boolean"/>
         <attr name="maxRows" format="integer" />
+        <attr name="delimiter" format="string" />
+        <attr name="delimiterRegex" format="boolean" />
 
         <attr name="chip_showDetails" format="boolean" />
         <attr name="chip_showAvatar" format="boolean" />


### PR DESCRIPTION
### Custom delimiters

This adds custom delimiter support which fixes #23. The delimiter can be set through XML or programmatically.

Example for setting a comma as the delimiter:
```xml
<com.tylersuehr.chips.ChipsInputLayout
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:hint="Start typing for chips..."
        app:delimiter=","/>
```

or programmatically:
```java
chipInputLayout.setDelimiter(",");
```

When the user types a comma anywhere in the edit text, the entire string will be split into tokens and the respective chips will be created in order. This also works for copy/paste.

The delimiter doesn't have to just be a single character. It can be a whole word or even a regex string. Here's an example with regex:

```xml
<com.tylersuehr.chips.ChipsInputLayout
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:hint="Start typing for chips..."
        app:delimiter="[0-9]+"
        app:delimiterRegex="true"/>
```

or programmatically:
```java
chipInputLayout.setDelimiter("[0-9]+", true);
```

This will tokenize the input using any number as the delimiter.

#### Upkeep

I've updated and tested the target and build SDKs and the support libraries. This will resolve the warnings in #33. 

Multiple Gradle keywords deprecated also and being removed at the end of 2018 and I've updated those accordingly in order to get rid of build warnings.

I intended to put these 2 commits in a separate branch and make a different pull request but I messed that up and don't know how to fix it, but I will figure it out if you need that 😄 